### PR TITLE
Update Android readme

### DIFF
--- a/demo/android/Readme.md
+++ b/demo/android/Readme.md
@@ -2,21 +2,22 @@
 
 ## Building for SDL beginners
 
-This folder contains several **Nuclear** implementations for **Android**.
-Has an Android dev you must be familiar whit JNI, SDL and C/C++ technologies.
-**SDL2** source code is mandatory in order to build the demos, yo can get a copy at: https://github.com/libsdl-org/SDL, clone it wherever you want, just don’t forget set the environment variable  `export SDLPATH=/wherever/you/put/SDL`
+This folder contains two **Nuklear** implementations for **Android** based on JNI/C and SDL2.
 
-You may have already settled yours environment vars for build other Android JNI projects `ANDROID_HOME` and `ANDROID_NDK_HOME`, if yours environments vars are different its opt to you add a new ones thats matches whit our build scripts or edit our demo build.sh in order to get the right paths.   
+The **SDL2** source code is required in order to build the demos. You can get a copy at <https://github.com/libsdl-org/SDL>. Clone it wherever you want and check out the latest SDL2 release tag, currently `release-2.30.9`.
 
-**Structure folder demos:**
-`sdl_opengl2`:
-This folder contains all the dependencies for build a project based on **OpenGL ES2**, to build the demo just execute ./build.sh, if everything goes ok you will see you demo at folder `build` named as ***com.demogles2.nuklear*** .
+The build script (`build.sh`) requires the environment variables `SDLPATH`, `ANDROID_HOME` and `ANDROID_NDK_HOME` to be set.
 
-`sdl2surface_rawfb`:
-This folder contains all the dependencies for build a project based on **Raw SDL Surface**,  OpenGL context will not be accessible inside this project, anyways under the hood SDL works with OpenGL, just like the previous demo you will found the project builded in folder `build` named as ***com.sdl2rawfb.nuklear*** .
+### Implemenations
 
-`build`:
-Has we have mentioned above, if builds were successfully, this folder will contains the demos ready to run on an Android device.        
+### sdl\_opengl2
 
- ## Building for SDL experts
- If you already are familiar whit SDL you con go strike forward to https://github.com/libsdl-org/SDL under the folder `build-scripts` you will see the script **androidbuild.sh**, this script will lead you to create a projects whit more flexibility.
+This folder contains all the dependencies for building a project based on **OpenGL ES2**. To build the demo just execute `./build.sh`. If everything goes ok, you will see your demo in `build/com.demogles2.nuklear/`.
+
+### sdl2surface\_rawfb
+
+This folder contains all the dependencies for building a project based on **Raw SDL Surface**. OpenGL context will not be accessible inside this project. Anyways under the hood SDL works with OpenGL. Just like the previous demo you will find the project build result in `build/com.sdl2rawfb.nuklear/`.
+
+## Building for SDL experts
+
+If you already are familiar with SDL, you can create your own build script based on SDL's original [androidbuild.sh](https://github.com/libsdl-org/SDL/blob/release-2.30.9/build-scripts/androidbuild.sh).


### PR DESCRIPTION
This is a proposal for updating the readme for your Android implementations:

* SDL's `main` branch is already on version 3. Tell the reader to checkout the latest SDL2 release.
* `androidbuild.sh` was removed from the `main` branch but it's still available on tag `release-2.30.9`. Linking to this file.
* Fix some typos.
* Express some things slightly differently.